### PR TITLE
remove sort key from websocket table and lambdas

### DIFF
--- a/infrastructure/cloudformation/websockets.yaml
+++ b/infrastructure/cloudformation/websockets.yaml
@@ -512,15 +512,11 @@ Resources:
       AttributeDefinitions:
       - AttributeName: "connection_id"
         AttributeType: "S"
-      - AttributeName: "timestamp"
-        AttributeType: "N"
       - AttributeName: "account"
         AttributeType: "S"
       KeySchema:
       - AttributeName: "connection_id"
         KeyType: "HASH"
-      - AttributeName: "timestamp"
-        KeyType: "RANGE"
       ProvisionedThroughput:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5

--- a/services/notification/notification-clear-faas/index.js
+++ b/services/notification/notification-clear-faas/index.js
@@ -40,7 +40,6 @@ const ws = new AWS.ApiGatewayManagementApi({ endpoint: process.env.WSS_CONNECTIO
 let cognito = new AWS.CognitoIdentityServiceProvider({ region: process.env.AWS_REGION })
 
 const WEBSOCKETS_TABLE_PARTITION_KEY = 'connection_id'
-const WEBSOCKETS_TABLE_SORT_KEY = 'timestamp'
 const WEBSOCKETS_TABLE_INDEX_NAME = 'account-index'
 const WEBSOCKET_TABLE_INDEX_ATTRIBUTE = 'account'
 const CLEARED_NOTIFICATIONS_PROPERTY = 'cleared'
@@ -113,8 +112,6 @@ exports.handler = async event => {
     websocketConnectionId
   )
 
-  let websocketCreationTimestamp = websocketItems[0].timestamp
-
   if (websocketItems.length > 0) {
     if (!websocketItems[0].account) {
       console.log(`adding ${accountFromJWT} to ${websocketConnectionId} connection id dynamodb record`)
@@ -122,9 +119,7 @@ exports.handler = async event => {
         ddb,
         process.env.WEBSOCKETS_TABLE_NAME,
         WEBSOCKETS_TABLE_PARTITION_KEY,
-        WEBSOCKETS_TABLE_SORT_KEY,
         websocketConnectionId,
-        websocketCreationTimestamp,
         WEBSOCKET_TABLE_INDEX_ATTRIBUTE, // newAttributeKey
         accountFromJWT, // newAttributeValue
         DYNAMODB_UPDATE_CONDITION_EXPRESSION // updateConditionExpression

--- a/services/notification/notification-clear-faas/index.test.js
+++ b/services/notification/notification-clear-faas/index.test.js
@@ -262,22 +262,17 @@ describe('lambda function', () => {
 
   test('calls updateItem with args', async () => {
     let ddb = {}
-    let tableName = process.env.WEBSOCKETS_TABLE_NAME
     let partitiionKey = 'connection_id'
-    let sortKey = 'timestamp'
     let connectionId = '123456789'
-    let timestamp = 12345678910
     let indexAttribute = 'account'
     let account = 'testaccount'
     let updateConditionExpression = 'attribute_not_exists'
     await handler(event)
     await expect(updateItem).toHaveBeenCalledWith(
       ddb,
-      tableName,
+      process.env.WEBSOCKETS_TABLE_NAME,
       partitiionKey,
-      sortKey,
       connectionId,
-      timestamp,
       indexAttribute,
       account,
       updateConditionExpression

--- a/services/notification/notification-clear-faas/lib/dynamodb.js
+++ b/services/notification/notification-clear-faas/lib/dynamodb.js
@@ -2,9 +2,7 @@ const updateItem = (
   service,
   table,
   partitionKey,
-  sortKey,
-  connectionId,
-  timestamp,
+  partitionKeyValue,
   newAttributeKey,
   newAttributeValue,
   updateConditionExpression
@@ -12,8 +10,7 @@ const updateItem = (
   let params = {
     TableName: table,
     Key: {
-      [partitionKey]: connectionId,
-      [sortKey]: timestamp
+      [partitionKey]: partitionKeyValue
     },
     ExpressionAttributeNames: {
       "#key": newAttributeKey
@@ -27,7 +24,7 @@ const updateItem = (
   return service.update(params)
     .promise()
     .then(async data => {
-      console.log(`${newAttributeValue} added to ${connectionId} connection_id record`)
+      console.log(`${newAttributeValue} added to ${partitionKeyValue} connection_id record`)
     })
     .catch(async err => {
       console.log(err, err.stack)

--- a/services/notification/notification-clear-faas/lib/dynamodb.test.js
+++ b/services/notification/notification-clear-faas/lib/dynamodb.test.js
@@ -37,17 +37,14 @@ describe('dynamodb', () => {
     let ddb = mockAws('update')
     let testtable = 'testtable'
     let testpartitionKey = 'testpartitionkey'
-    let testsortkey = 'testsortkey'
     let testconnectionid = 'testconnectionid'
-    let testtimestamp = 'testtimestamp'
     let testattributekey = 'testattributekey'
     let testattributevalue = 'testattributevalue'
     let testupdateconditionexpression = 'testupdateconditionexpression'
     let expected = {
       TableName: testtable,
       Key: {
-        [testpartitionKey]: testconnectionid,
-        [testsortkey]: testtimestamp
+        [testpartitionKey]: testconnectionid
       },
       ExpressionAttributeNames: {
         "#key": testattributekey
@@ -58,13 +55,11 @@ describe('dynamodb', () => {
       UpdateExpression: `SET #key = :value`,
       ConditionExpression: `${testupdateconditionexpression}(#key)` // 'attribute_not_exists'
     }
-    let result = updateItem(
+    updateItem(
       ddb,
       testtable,
       testpartitionKey,
-      testsortkey,
       testconnectionid,
-      testtimestamp,
       testattributekey,
       testattributevalue,
       testupdateconditionexpression

--- a/services/notification/notification-get-faas/index.js
+++ b/services/notification/notification-get-faas/index.js
@@ -40,7 +40,6 @@ let cognito = new AWS.CognitoIdentityServiceProvider({
 })
 
 const WEBSOCKETS_TABLE_PARTITION_KEY = 'connection_id'
-const WEBSOCKETS_TABLE_SORT_KEY = 'timestamp'
 const NOTIFICATIONS_TABLE_INDEX_NAME = 'account-index'
 const NOTIFICATIONS_TABLE_INDEX_ATTRIBUTE = 'account'
 const WEBSOCKET_TABLE_INDEX_ATTRIBUTE = 'account'
@@ -120,8 +119,6 @@ exports.handler = async event => {
     websocketConnectionId
   )
 
-  let websocketCreationTimestamp = websocketItems[0].timestamp
-
   // console.log(websocketItems)
   // add account value to connection id record if not included
   if (websocketItems.length > 0) {
@@ -131,9 +128,7 @@ exports.handler = async event => {
         ddb,
         process.env.WEBSOCKETS_TABLE_NAME,
         WEBSOCKETS_TABLE_PARTITION_KEY,
-        WEBSOCKETS_TABLE_SORT_KEY,
         websocketConnectionId,
-        websocketCreationTimestamp,
         WEBSOCKET_TABLE_INDEX_ATTRIBUTE, // newAttributeKey
         accountFromJWT, // newAttributeValue
         DYNAMODB_UPDATE_CONDITION_EXPRESSION // updateConditionExpression

--- a/services/notification/notification-get-faas/index.test.js
+++ b/services/notification/notification-get-faas/index.test.js
@@ -268,22 +268,17 @@ describe('lambda function', () => {
 
   test('calls updateItem with args', async () => {
     let ddb = {}
-    let tableName = process.env.WEBSOCKETS_TABLE_NAME
     let partitiionKey = 'connection_id'
-    let sortKey = 'timestamp'
     let connectionId = '123456789'
-    let timestamp = 12345678910
     let indexAttribute = 'account'
     let account = 'testaccount'
     let updateConditionExpression = 'attribute_not_exists'
     await handler(event)
     await expect(updateItem).toHaveBeenCalledWith(
       ddb,
-      tableName,
+      process.env.WEBSOCKETS_TABLE_NAME,
       partitiionKey,
-      sortKey,
       connectionId,
-      timestamp,
       indexAttribute,
       account,
       updateConditionExpression

--- a/services/notification/notification-get-faas/lib/dynamodb.js
+++ b/services/notification/notification-get-faas/lib/dynamodb.js
@@ -2,9 +2,7 @@ const updateItem = (
   service,
   table,
   partitionKey,
-  sortKey,
-  connectionId,
-  timestamp,
+  partitionKeyValue,
   newAttributeKey,
   newAttributeValue,
   updateConditionExpression
@@ -12,8 +10,7 @@ const updateItem = (
   let params = {
     TableName: table,
     Key: {
-      [partitionKey]: connectionId,
-      [sortKey]: timestamp
+      [partitionKey]: partitionKeyValue
     },
     ExpressionAttributeNames: {
       "#key": newAttributeKey
@@ -27,7 +24,7 @@ const updateItem = (
   return service.update(params)
     .promise()
     .then(async data => {
-      console.log(`${newAttributeValue} added to ${connectionId} connection_id record`)
+      console.log(`${newAttributeValue} added to ${partitionKeyValue} connection_id record`)
     })
     .catch(async err => {
       console.log(err, err.stack)

--- a/services/notification/notification-get-faas/lib/dynamodb.test.js
+++ b/services/notification/notification-get-faas/lib/dynamodb.test.js
@@ -31,17 +31,14 @@ describe('dynamodb', () => {
     let ddb = mockAws('update')
     let testtable = 'testtable'
     let testpartitionKey = 'testpartitionkey'
-    let testsortkey = 'testsortkey'
     let testconnectionid = 'testconnectionid'
-    let testtimestamp = 'testtimestamp'
     let testattributekey = 'testattributekey'
     let testattributevalue = 'testattributevalue'
     let testupdateconditionexpression = 'testupdateconditionexpression'
     let expected = {
       TableName: testtable,
       Key: {
-        [testpartitionKey]: testconnectionid,
-        [testsortkey]: testtimestamp
+        [testpartitionKey]: testconnectionid
       },
       ExpressionAttributeNames: {
         "#key": testattributekey
@@ -52,13 +49,11 @@ describe('dynamodb', () => {
       UpdateExpression: `SET #key = :value`,
       ConditionExpression: `${testupdateconditionexpression}(#key)` // 'attribute_not_exists'
     }
-    let result = updateItem(
+    updateItem(
       ddb,
       testtable,
       testpartitionKey,
-      testsortkey,
       testconnectionid,
-      testtimestamp,
       testattributekey,
       testattributevalue,
       testupdateconditionexpression

--- a/services/notification/wss-notif-connect-faas/index.js
+++ b/services/notification/wss-notif-connect-faas/index.js
@@ -2,46 +2,46 @@ const AWS = require('aws-sdk')
 
 const {
   putItem,
-  queryTable,
   deleteConnection
 } = require('./lib/awsServices')
 
-const WEBSOCKETS_TABLE_NAME = process.env.WEBSOCKETS_TABLE_NAME
-const AWS_REGION = process.env.AWS_REGION
+// env var inventory (avoid const assignments):
+// process.env.WEBSOCKETS_TABLE_NAME
+// process.env.AWS_REGION
+
 const WEBSOCKET_TABLE_PRIMARY_KEY = 'connection_id'
-const WEBSOCKET_TABLE_SORT_KEY = 'timestamp'
+const WEBSOCKET_TABLE_CONNECTED_AT_ATTRIBUTE = 'created_at'
 
 
 exports.handler = async event => {
   console.log(JSON.stringify(event))
 
-  let ddb = new AWS.DynamoDB.DocumentClient({ region: AWS_REGION})
+  let ddb = new AWS.DynamoDB.DocumentClient({
+    region: process.env.AWS_REGION
+  })
+  let connectedAt = event.requestContext.connectedAt
   let connectionId = event.requestContext.connectionId
 
   // store connection id in ddb
   if (event.requestContext.eventType === "CONNECT") {
 
-    let time = Date.now()
-    await putItem(ddb, WEBSOCKETS_TABLE_NAME, time, connectionId)
+    await putItem(
+      ddb,
+      process.env.WEBSOCKETS_TABLE_NAME,
+      WEBSOCKET_TABLE_PRIMARY_KEY,
+      connectionId,
+      WEBSOCKET_TABLE_CONNECTED_AT_ATTRIBUTE,
+      connectedAt
+    )
 
   // or delete connection id item if disconnecting web websocket
   } else if (event.requestContext.eventType === "DISCONNECT") {
 
-    let connectionValues = await queryTable(
-      ddb,
-      WEBSOCKETS_TABLE_NAME,
-      WEBSOCKET_TABLE_PRIMARY_KEY,
-      connectionId
-    )
-
-    let singleConnection = connectionValues[0]
-
     await deleteConnection(
       ddb,
-      WEBSOCKETS_TABLE_NAME,
+      process.env.WEBSOCKETS_TABLE_NAME,
       WEBSOCKET_TABLE_PRIMARY_KEY,
-      WEBSOCKET_TABLE_SORT_KEY,
-      singleConnection
+      connectionId
     )
 
   } else {

--- a/services/notification/wss-notif-connect-faas/lib/awsServices.js
+++ b/services/notification/wss-notif-connect-faas/lib/awsServices.js
@@ -1,37 +1,22 @@
-const putItem = (service, table, time, connectionId) => {
+const putItem = (
+  service,
+  table,
+  primaryKey,
+  primaryKeyValue,
+  attributeKey,
+  attributeValue
+  ) => {
   let params = {
     TableName: table,
     Item: {
-      connection_id: connectionId,
-      timestamp: time
+      [primaryKey]: primaryKeyValue,
+      [attributeKey]: attributeValue
     }
   }
   return service.put(params)
     .promise()
     .then(async data => {
-      console.log(`connectionId stored: ${connectionId}`)
-    })
-    .catch(async err => {
-      console.log(err, err.stack)
-      throw err
-    })
-}
-
-const queryTable = (service, table, key, val) => {
-  let params = {
-    TableName: table,
-    KeyConditions: {
-      [key]: {
-        ComparisonOperator: 'EQ',
-        AttributeValueList: [ val ]
-      }
-    }
-  }
-  return service.query(params)
-    .promise()
-    .then(async data => {
-      console.log(data.Items)
-      return data.Items
+      console.log(`connectionId stored: ${attributeValue}`)
     })
     .catch(async err => {
       console.log(err, err.stack)
@@ -43,20 +28,18 @@ const deleteConnection = (
   service,
   table,
   primaryKey,
-  sortKey,
-  connection
+  primaryKeyValue,
   ) => {
     let params = {
       TableName: table,
       Key: {
-        [primaryKey]: connection.connection_id,
-        [sortKey]: connection.timestamp
+        [primaryKey]: primaryKeyValue
       }
     }
     return service.delete(params)
       .promise()
       .then(async data => {
-        console.log(`connection_id for '${connection.account}' account deleted: ${connection.connection_id}`)
+        console.log(`deleted connection_id: '${primaryKeyValue}'`)
       })
       .catch(async err => {
         console.log(err, err.stack)
@@ -66,6 +49,5 @@ const deleteConnection = (
 
 module.exports = {
   putItem,
-  queryTable,
   deleteConnection
 }

--- a/services/notification/wss-notif-connect-faas/lib/awsServices.test.js
+++ b/services/notification/wss-notif-connect-faas/lib/awsServices.test.js
@@ -1,6 +1,5 @@
 const {
   putItem,
-  queryTable,
   deleteConnection
 } = require('./awsServices')
 
@@ -27,54 +26,33 @@ describe('awsServices', () => {
   test('putItem params', () => {
     let ddb = mockAws('put')
     let table = 'testtable'
-    let time = Date.now()
-    let connectionId = 'testconnection'
+    let primaryKey = 'connection_id'
+    let primaryKeyValue = 'testconnection'
+    let attributeKey = 'created_at'
+    let attributeKeyValue = 1573440182072
     let expected = {
       TableName: table,
       Item: {
-        connection_id: connectionId,
-        timestamp: time
+        [primaryKey]: primaryKeyValue,
+        [attributeKey]: attributeKeyValue
       }
     }
-    putItem(ddb, table, time, connectionId)
+    putItem(ddb, table, primaryKey, primaryKeyValue, attributeKey, attributeKeyValue)
     expect(ddb.put).toHaveBeenCalledWith(expected)
-  })
-
-  test('queryTable params', () => {
-    let ddb = mockAws('query')
-    let table = 'testtable'
-    let key = 'connection_id'
-    let val = '123456789'
-    let expected = {
-      TableName: table,
-      KeyConditions: {
-        [key]: {
-          ComparisonOperator: 'EQ',
-          AttributeValueList: [ val ]
-        }
-      }
-    }
-    queryTable(ddb, table, key, val)
-    expect(ddb.query).toHaveBeenCalledWith(expected)
   })
 
   test('deleteConnection params', () => {
     let ddb = mockAws('delete')
     let table = 'testtable'
     let primaryKey = 'connection_id'
-    let sortKey = 'timestamp'
-    let connection = {
-      connection_id: '123456789',
-      timestamp: Date.now()
-    }
+    let primaryKeyValue = 'testconnection'
     let expected = {
       TableName: table,
       Key: {
-        [primaryKey]: connection.connection_id,
-        [sortKey]: connection.timestamp
+        [primaryKey]: primaryKeyValue,
       }
     }
-    deleteConnection(ddb, table, primaryKey, sortKey, connection)
+    deleteConnection(ddb, table, primaryKey, primaryKeyValue)
     expect(ddb.delete).toHaveBeenCalledWith(expected)
   })
 

--- a/services/notification/wss-notif-connect-faas/tests/index.integ.js
+++ b/services/notification/wss-notif-connect-faas/tests/index.integ.js
@@ -4,7 +4,6 @@ const WebSocket = require('ws')
 const {
   createAccount,
   deleteAccount,
-  queryIndex,
   queryTable
 } = require('./utils/integrationTestHelpers')
 
@@ -21,8 +20,6 @@ const randomFourDigitInt = () => {
 
 const TEST_ACCOUNT = `FakerAccount${randomFourDigitInt()}`
 const WEBSOCKET_TABLE_RANGE_KEY = 'connection_id'
-const WEBSOCKET_ATTRIBUTE = 'account'
-const WEBSOCKET_INDEX_NAME = `${WEBSOCKET_ATTRIBUTE}-index`
 
 const cognitoIdsp = new AWS.CognitoIdentityServiceProvider()
 const ddb = new AWS.DynamoDB.DocumentClient({ region: process.env.AWS_REGION })

--- a/services/notification/wss-notif-connect-faas/tests/utils/integrationTestHelpers.js
+++ b/services/notification/wss-notif-connect-faas/tests/utils/integrationTestHelpers.js
@@ -54,31 +54,6 @@ const getToken = async (service, clientId, account, secret) => {
     .catch(err => err)
 }
 
-const queryIndex = (
-  service, table, indexName, key, val
-  ) => {
-  let params = {
-    TableName: table,
-    IndexName: indexName,
-    KeyConditions: {
-      [key]: {
-        ComparisonOperator: 'EQ',
-        AttributeValueList: [ val ]
-      }
-    }
-  }
-  return service.query(params)
-    .promise()
-    .then(async data => {
-      // console.log(data.Items)
-      return data.Items
-    })
-    .catch(async err => {
-      console.log(err, err.stack)
-      throw err
-    })
-}
-
 const queryTable = (service, table, key, val) => {
   let params = {
     TableName: table,
@@ -105,6 +80,5 @@ module.exports = {
   createAccount,
   deleteAccount,
   getToken,
-  queryIndex,
   queryTable
 }


### PR DESCRIPTION
observing lingering connection ids in websocket table despite lambda logs reporting removal.
connection ids issued as unique.
removing timestamp sort key to simplify dynamodb requests