### PR TITLE
Fix graphql integration test

### DIFF
--- a/services/graphql-faas/tests/transactions/transaction.test.js
+++ b/services/graphql-faas/tests/transactions/transaction.test.js
@@ -129,7 +129,7 @@ describe('graphql transact', () => {
       user: TEST_ACCOUNT
     })
     response.transactions.forEach(item => {
-      expect([item.debitor, item.creditor]).toContain(TEST_ACCOUNT)
+      expect([item.debitor, item.creditor, item.author]).toContain(TEST_ACCOUNT)
     })
   })
 })


### PR DESCRIPTION
Transaction author column was recently included in values queried by measure of service. This adjusts graphql integration tests to consider author value. 