### PR TITLE
cleanup build and deploy workflow configuration files

### DIFF
--- a/.github/workflows/dev-auto-confirm.yaml
+++ b/.github/workflows/dev-auto-confirm.yaml
@@ -6,11 +6,6 @@ on:
     - 'infrastructure/terraform/aws/modules/environment/common-bin/cognito/auto-confirm/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'infrastructure/terraform/aws/modules/environment/common-bin/cognito/auto-confirm/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   build:
@@ -23,17 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
-      - name: clean directory
-        run: make clean
-        working-directory: infrastructure/terraform/aws/modules/environment/common-bin/cognito/auto-confirm
       - name: create zip for deployment
         run: make zip
         working-directory: infrastructure/terraform/aws/modules/environment/common-bin/cognito/auto-confirm

--- a/.github/workflows/dev-clone.yaml
+++ b/.github/workflows/dev-clone.yaml
@@ -6,11 +6,6 @@ on:
     - 'schema/clone-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'schema/clone-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   build:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: create zip for deployment
         run: make zip
         working-directory: schema/clone-faas

--- a/.github/workflows/dev-delete-faker-cognito.yaml
+++ b/.github/workflows/dev-delete-faker-cognito.yaml
@@ -6,11 +6,6 @@ on:
     - 'infrastructure/terraform/aws/modules/environment/common-bin/cognito/delete-faker-accounts/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'infrastructure/terraform/aws/modules/environment/common-bin/cognito/delete-faker-accounts/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   build:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: clean directory
         run: make clean
         working-directory: infrastructure/terraform/aws/modules/environment/common-bin/cognito/delete-faker-accounts

--- a/.github/workflows/dev-delete-faker-rds.yaml
+++ b/.github/workflows/dev-delete-faker-rds.yaml
@@ -6,11 +6,6 @@ on:
     - 'infrastructure/terraform/aws/modules/environment/common-bin/rds/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'infrastructure/terraform/aws/modules/environment/common-bin/rds/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   build:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: clean directory
         run: make clean-artifact
         working-directory: infrastructure/terraform/aws/modules/environment/common-bin/rds

--- a/.github/workflows/dev-deploy-lambda.yaml
+++ b/.github/workflows/dev-deploy-lambda.yaml
@@ -6,11 +6,6 @@ on:
     - 'infrastructure/terraform/aws/modules/environment/common-bin/deploy-lambda/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'infrastructure/terraform/aws/modules/environment/common-bin/deploy-lambda/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   build:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: clean
         run: make clean
         working-directory: infrastructure/terraform/aws/modules/environment/common-bin/deploy-lambda

--- a/.github/workflows/dev-graphql.yaml
+++ b/.github/workflows/dev-graphql.yaml
@@ -6,11 +6,6 @@ on:
     - 'services/graphql-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'services/graphql-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -22,15 +17,6 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       CI: true
     steps:
-      - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: make install
         working-directory: services/graphql-faas

--- a/.github/workflows/dev-graphql.yaml
+++ b/.github/workflows/dev-graphql.yaml
@@ -6,7 +6,7 @@ on:
     - 'services/graphql-faas/**'
     branches-ignore:
     - 'master'
-
+    
 jobs:
   test:
     name: graphql-faas unit and integration tests
@@ -17,6 +17,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       CI: true
     steps:
+      - uses: actions/checkout@v1
       - name: install dependencies
         run: make install
         working-directory: services/graphql-faas

--- a/.github/workflows/dev-measure.yaml
+++ b/.github/workflows/dev-measure.yaml
@@ -6,11 +6,6 @@ on:
     - 'services/measure-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'services/measure-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   build:
@@ -23,10 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use default go
-        uses: actions/setup-go@v1
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: |
           export GOPATH=$(go env GOPATH)

--- a/.github/workflows/dev-migrate.yaml
+++ b/.github/workflows/dev-migrate.yaml
@@ -6,11 +6,6 @@ on:
     - 'schema/migrate-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'schema/migrate-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   build:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: create zip for deployment
         run: make zip
         working-directory: schema/migrate-faas

--- a/.github/workflows/dev-notification-clear.yaml
+++ b/.github/workflows/dev-notification-clear.yaml
@@ -6,11 +6,6 @@ on:
     - 'services/notification/notification-clear-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'services/notification/notification-clear-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: make install
         working-directory: services/notification/notification-clear-faas

--- a/.github/workflows/dev-notification-get.yaml
+++ b/.github/workflows/dev-notification-get.yaml
@@ -6,11 +6,6 @@ on:
     - 'services/notification/notification-get-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'services/notification/notification-get-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: make install
         working-directory: services/notification/notification-get-faas

--- a/.github/workflows/dev-notification-send.yaml
+++ b/.github/workflows/dev-notification-send.yaml
@@ -6,11 +6,6 @@ on:
     - 'services/notification/notification-send-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'services/notification/notification-send-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: make install
         working-directory: services/notification/notification-send-faas

--- a/.github/workflows/dev-react.yaml
+++ b/.github/workflows/dev-react.yaml
@@ -6,11 +6,6 @@ on:
     - 'react/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'react/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: make install
         working-directory: react

--- a/.github/workflows/dev-rules.yaml
+++ b/.github/workflows/dev-rules.yaml
@@ -6,11 +6,6 @@ on:
     - 'services/rules-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'services/rules-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies and execute unit tests
         run: make test-unit ENV=dev
         working-directory: services/rules-faas

--- a/.github/workflows/dev-s3-event.yaml
+++ b/.github/workflows/dev-s3-event.yaml
@@ -19,7 +19,7 @@ jobs:
     steps: 
       - uses: actions/checkout@v1
       - name: add python3-venv to build server
-        run: apt-get install python3-venv
+        run: sudo apt-get install python3-venv
       - name: install environment
         run: make install-env
         working-directory: infrastructure/cloudformation/s3-event-faas

--- a/.github/workflows/dev-s3-event.yaml
+++ b/.github/workflows/dev-s3-event.yaml
@@ -6,11 +6,6 @@ on:
     - 'infrastructure/cloudformation/s3-event-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'infrastructure/cloudformation/s3-event-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -23,13 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-          architecture: 'x64'
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install environment
         run: make install-env
         working-directory: infrastructure/cloudformation/s3-event-faas

--- a/.github/workflows/dev-s3-event.yaml
+++ b/.github/workflows/dev-s3-event.yaml
@@ -16,8 +16,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: us-east-1
       CI: true
-    steps:
+    steps: 
       - uses: actions/checkout@v1
+      - name: add python3-venv to build server
+        run: apt-get install python3-venv
       - name: install environment
         run: make install-env
         working-directory: infrastructure/cloudformation/s3-event-faas

--- a/.github/workflows/dev-transact.yaml
+++ b/.github/workflows/dev-transact.yaml
@@ -6,11 +6,6 @@ on:
     - 'services/transact-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'services/transact-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies and execute unit tests
         run: make test-unit ENV=dev
         working-directory: services/transact-faas

--- a/.github/workflows/dev-wss-notif-connect.yaml
+++ b/.github/workflows/dev-wss-notif-connect.yaml
@@ -6,11 +6,6 @@ on:
     - 'services/notification/wss-notif-connect-faas/**'
     branches-ignore:
     - 'master'
-  pull_request:
-    paths:
-    - 'services/notification/wss-notif-connect-faas/**'
-    branches-ignore:
-    - 'master'
 
 jobs:
   test:
@@ -23,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: make install
         working-directory: services/notification/wss-notif-connect-faas

--- a/.github/workflows/prod-auto-confirm.yaml
+++ b/.github/workflows/prod-auto-confirm.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: clean directory
         run: make clean
         working-directory: infrastructure/terraform/aws/modules/environment/common-bin/cognito/auto-confirm

--- a/.github/workflows/prod-clone.yaml
+++ b/.github/workflows/prod-clone.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: create zip for deployment
         run: make zip
         working-directory: schema/clone-faas

--- a/.github/workflows/prod-delete-faker-cognito.yaml
+++ b/.github/workflows/prod-delete-faker-cognito.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: clean directory
         run: make clean
         working-directory: infrastructure/terraform/aws/modules/environment/common-bin/cognito/delete-faker-accounts

--- a/.github/workflows/prod-delete-faker-rds.yaml
+++ b/.github/workflows/prod-delete-faker-rds.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: clean directory
         run: make clean-artifact
         working-directory: infrastructure/terraform/aws/modules/environment/common-bin/rds

--- a/.github/workflows/prod-deploy-lambda.yaml
+++ b/.github/workflows/prod-deploy-lambda.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: clean
         run: make clean
         working-directory: infrastructure/terraform/aws/modules/environment/common-bin/deploy-lambda

--- a/.github/workflows/prod-graphql.yaml
+++ b/.github/workflows/prod-graphql.yaml
@@ -18,14 +18,6 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: make install
         working-directory: services/graphql-faas

--- a/.github/workflows/prod-measure.yaml
+++ b/.github/workflows/prod-measure.yaml
@@ -18,10 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use default go
-        uses: actions/setup-go@v1
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: |
           export GOPATH=$(go env GOPATH)

--- a/.github/workflows/prod-migrate.yaml
+++ b/.github/workflows/prod-migrate.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: create zip for deployment
         run: make zip
         working-directory: schema/migrate-faas

--- a/.github/workflows/prod-notification-clear.yaml
+++ b/.github/workflows/prod-notification-clear.yaml
@@ -18,14 +18,6 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: deploy
         working-directory: services/notification/notification-clear-faas
         run: make deploy ENV=prod

--- a/.github/workflows/prod-notification-get.yaml
+++ b/.github/workflows/prod-notification-get.yaml
@@ -18,14 +18,6 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: deploy
         working-directory: services/notification/notification-get-faas
-        run: make deploy ENV=prod
+        run: make initial-deploy ENV=prod

--- a/.github/workflows/prod-notification-send.yaml
+++ b/.github/workflows/prod-notification-send.yaml
@@ -18,14 +18,6 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: deploy
         working-directory: services/notification/notification-send-faas
         run: make deploy ENV=prod

--- a/.github/workflows/prod-react.yaml
+++ b/.github/workflows/prod-react.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install dependencies
         run: make install
         working-directory: react

--- a/.github/workflows/prod-rules.yaml
+++ b/.github/workflows/prod-rules.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: deploy
         working-directory: services/rules-faas
         run: make deploy ENV=prod

--- a/.github/workflows/prod-s3-event.yaml
+++ b/.github/workflows/prod-s3-event.yaml
@@ -18,6 +18,8 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
+      - name: add python3-venv to build server
+        run: sudo apt-get install python3-venv
       - name: install environment
         run: make install-env
         working-directory: infrastructure/cloudformation/s3-event-faas

--- a/.github/workflows/prod-s3-event.yaml
+++ b/.github/workflows/prod-s3-event.yaml
@@ -18,13 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-          architecture: 'x64'
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: install environment
         run: make install-env
         working-directory: infrastructure/cloudformation/s3-event-faas

--- a/.github/workflows/prod-transact.yaml
+++ b/.github/workflows/prod-transact.yaml
@@ -18,14 +18,6 @@ jobs:
       CI: true
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: deploy
         working-directory: services/transact-faas
         run: make deploy ENV=prod

--- a/.github/workflows/prod-wss-notif-connect.yaml
+++ b/.github/workflows/prod-wss-notif-connect.yaml
@@ -18,14 +18,6 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v1
-      - name: use node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: install yarn
-        uses: sergioramos/yarn-actions/install@master
-      - name: install aws cli
-        uses: chrislennon/action-aws-cli@v1.1
       - name: deploy
         working-directory: services/notification/wss-notif-connect-faas
         run: make deploy ENV=prod

--- a/infrastructure/cloudformation/s3-event-faas/makefile
+++ b/infrastructure/cloudformation/s3-event-faas/makefile
@@ -62,7 +62,7 @@ dev: test
 zip: clean-artifact
 		zip -r -j $(APP_NAME)-src.zip src/main.py
 
-# aliases test target which creates tested artifact
+# aliases test target which creates tested artifact 
 .PHONY: src zip
 src: zip
 

--- a/infrastructure/cloudformation/s3-event-faas/makefile
+++ b/infrastructure/cloudformation/s3-event-faas/makefile
@@ -27,7 +27,7 @@ clean: clean-deps clean-artifact
 
 .PHONY: install-env clean-deps
 install-env: clean-deps
-		@python3.7 -m venv .; \
+		@python3 -m venv .; \
 		. ./bin/activate; \
 		pip install pipenv
 

--- a/infrastructure/cloudformation/s3-event-faas/src/main.py
+++ b/infrastructure/cloudformation/s3-event-faas/src/main.py
@@ -20,6 +20,7 @@ topic_list_name = 'TopicConfigurations'
 print('Loading function')
 s3 = boto3.client('s3')
 
+
 def lambda_handler(event, context):
     print("Received event:")
     print(event)

--- a/infrastructure/cloudformation/s3-event-faas/src/main.py
+++ b/infrastructure/cloudformation/s3-event-faas/src/main.py
@@ -20,7 +20,6 @@ topic_list_name = 'TopicConfigurations'
 print('Loading function')
 s3 = boto3.client('s3')
 
-
 def lambda_handler(event, context):
     print("Received event:")
     print(event)

--- a/infrastructure/terraform/aws/modules/environment/common-bin/cognito/auto-confirm/index.js
+++ b/infrastructure/terraform/aws/modules/environment/common-bin/cognito/auto-confirm/index.js
@@ -2,6 +2,7 @@ const AWS = require('aws-sdk')
 
 exports.handler = (event, context, callback) => {
   //auto-confirm user in Cognito
+  
   const modifiedEvent = event
   modifiedEvent.response.autoConfirmUser = true
   console.log(event.response)

--- a/infrastructure/terraform/aws/modules/environment/common-bin/cognito/delete-faker-accounts/index.js
+++ b/infrastructure/terraform/aws/modules/environment/common-bin/cognito/delete-faker-accounts/index.js
@@ -76,5 +76,4 @@ exports.handler = async (event) => {
   } else {
     return
   }
-
 }

--- a/infrastructure/terraform/aws/modules/environment/common-bin/deploy-lambda/index.js
+++ b/infrastructure/terraform/aws/modules/environment/common-bin/deploy-lambda/index.js
@@ -96,4 +96,5 @@ exports.handler = async (event) => {
   } else {
     return `no layer or src matched in evented ${S3Key} update`
   }
+  
 }

--- a/infrastructure/terraform/aws/modules/environment/common-bin/rds/index.js
+++ b/infrastructure/terraform/aws/modules/environment/common-bin/rds/index.js
@@ -1,5 +1,6 @@
 const { Client } = require('pg')
 
+
 exports.handler = async (event) => {
   let client = new Client()
   await client.connect()

--- a/react/e2e/constants.js
+++ b/react/e2e/constants.js
@@ -81,6 +81,7 @@ const SELECTORS = {
   appVersionLabel: '[data-id="appVersion"]'
 }
 
+
 module.exports = {
   SELECTORS,
   BASE_URL,

--- a/schema/clone-faas/index.sh
+++ b/schema/clone-faas/index.sh
@@ -45,6 +45,7 @@ handler () {
     cat "$WRITABLE_LAMBDA_PATH/invoke.log"
     printf "\n"
 
+
     # ...must send your return value to stderr https://github.com/gkrizek/bash-lambda-layer/blob/master/README.md#caveats
     echo "$(cat $WRITABLE_LAMBDA_PATH/invoke.log)" >&2
 }

--- a/schema/migrate-faas/index.js
+++ b/schema/migrate-faas/index.js
@@ -40,4 +40,5 @@ exports.handler = async event => {
     migrationsTable: MIGRATIONS_TABLE_NAME
   }
   return runner(opts)
+  
 }

--- a/services/graphql-faas/test-data
+++ b/services/graphql-faas/test-data
@@ -15,6 +15,7 @@ Body:raw
   }
 }
 
+
 // 2019-04-15
 
 mutation createTransaction($items: [TransactionCreateType]!) {

--- a/services/graphql-faas/test-data
+++ b/services/graphql-faas/test-data
@@ -15,7 +15,6 @@ Body:raw
   }
 }
 
-
 // 2019-04-15
 
 mutation createTransaction($items: [TransactionCreateType]!) {

--- a/services/measure-faas/main.go
+++ b/services/measure-faas/main.go
@@ -101,4 +101,5 @@ func handleLambdaEvent(ctx context.Context, event lambdaEvent) (string, error) {
 
 func main() {
 	lambda.Start(handleLambdaEvent)
+	
 }

--- a/services/notification/notification-clear-faas/index.js
+++ b/services/notification/notification-clear-faas/index.js
@@ -181,4 +181,5 @@ exports.handler = async event => {
   return {
     statusCode: 200
   }
+  
 }

--- a/services/notification/notification-get-faas/index.js
+++ b/services/notification/notification-get-faas/index.js
@@ -182,5 +182,4 @@ exports.handler = async event => {
   return {
     statusCode: 200
   }
-
 }

--- a/services/notification/notification-get-faas/makefile
+++ b/services/notification/notification-get-faas/makefile
@@ -115,8 +115,8 @@ deploy-layer: layer
 			--output=text | sed 's/"//g'); \
 #		echo "***Deployed $(ENV)/$(APP_NAME)-src.zip from s3 ETag: $$ETAG"
 
-.PHONY: deploy test-env-arg src
-deploy: test-env-arg src # lambda layer NOT deployed
+.PHONY: deploy src
+deploy: src # lambda layer NOT deployed
 		@ETAG=$$(aws s3api put-object \
 			--bucket=$(ARTIFACT_BUCKET)-$(ENV) \
 			--key=$(APP_NAME)-src.zip \

--- a/services/notification/notification-send-faas/index.js
+++ b/services/notification/notification-send-faas/index.js
@@ -139,4 +139,5 @@ exports.handler = async event => {
       console.log('0 notifcation websockets for account: ', account)
     }
   }
+  
 }

--- a/services/notification/wss-notif-connect-faas/index.js
+++ b/services/notification/wss-notif-connect-faas/index.js
@@ -95,4 +95,5 @@ exports.handler = async event => {
   return {
     statusCode: 200
   }
+  
 }

--- a/services/rules-faas/index.js
+++ b/services/rules-faas/index.js
@@ -41,6 +41,5 @@ exports.handler = async event => {
     RULE_INSTANCE_ID_FUNCTION_PARAMETER_NAME,
     RULE_INSTANCE_TRANSACTIONS_ITEMS_FUNCTION_PARAMETER_NAME,
   )
-
   return transactionsWithRulesApplied
 }

--- a/services/transact-faas/index.js
+++ b/services/transact-faas/index.js
@@ -95,4 +95,5 @@ exports.handler = async event => {
     status: STATUS_SUCCESS,
     data: storedTransactions
   }
+  
 }


### PR DESCRIPTION
* reduce build trigger to push event only 
* remove build dependency install steps for dependencies already available in build server
* add `python-venv` back to python workflow after removing custom python dependency installation and python3.7 reference
